### PR TITLE
Fix typo in FTS acceleration setting

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -118,7 +118,7 @@ class IColumn;
     M(UInt64, max_build_binary_vector_index_train_block_size, 2 * 1024 * 1024, "Maximum block size in bytes for training Binary vectors in build index", 0) \
     M(UInt64, max_build_index_add_block_size, 10 * 1024 * 1024, "Maximum block size in bytes for adding vectors in one round of build index", 0) \
     M(Bool, optimize_move_to_prewhere_for_vector_search, true, "Enables or disables special PREWHERE optimization for vector search in SELECT queries which move all viable WHERE to PREWHERE.", 0) \
-    M(Bool, enbale_fts_index_for_string_functions, false, "Enable the FTS index to accelerate functions for searching in strings (e.g., LIKE, hasToken, startsWith). Only the raw tokenizer can ensure correct results.", 0) \
+    M(Bool, enable_fts_index_for_string_functions, false, "Enable the FTS index to accelerate functions for searching in strings (e.g., LIKE, hasToken, startsWith). Only the raw tokenizer can ensure correct results.", 0) \
     M(UInt64, max_replicated_fetches_network_bandwidth_for_server, 0, "The maximum speed of data exchange over the network in bytes per second for replicated fetches. Zero means unlimited. Only has meaning at server startup.", 0) \
     M(UInt64, max_replicated_sends_network_bandwidth_for_server, 0, "The maximum speed of data exchange over the network in bytes per second for replicated sends. Zero means unlimited. Only has meaning at server startup.", 0) \
     M(UInt64, max_remote_read_network_bandwidth_for_server, 0, "The maximum speed of data exchange over the network in bytes per second for read. Zero means unlimited. Only has meaning at server startup.", 0) \

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1677,9 +1677,9 @@ MarkRanges MergeTreeDataSelectExecutor::generateMarkRangesFromTantivy(
         return index_ranges;
     }
     // Boundary
-    UInt64 enbale_fts_index_for_string_functions = settings.enbale_fts_index_for_string_functions;
-    LOG_DEBUG(log, "enbale_fts_index_for_string_functions: {}", enbale_fts_index_for_string_functions);
-    if (enbale_fts_index_for_string_functions == 0)
+    UInt64 enable_fts_index_for_string_functions = settings.enable_fts_index_for_string_functions;
+    LOG_DEBUG(log, "enable_fts_index_for_string_functions: {}", enable_fts_index_for_string_functions);
+    if (enable_fts_index_for_string_functions == 0)
     {
         return index_ranges;
     }


### PR DESCRIPTION
The [documentation mentions](https://myscale.com/docs/en/text-search/#accelerating-built-in-string-functions):

> To control whether the FTS index is enabled when executing these string functions, a query setting named enable_fts_index_for_string_functions

However this setting is misspelled in the code so you will see errors like:

> SQL Error [115] [07000]: Code: 115. DB::Exception: Unknown setting enable_fts_index_for_string_functions: Maybe you meant ['enbale_fts_index_for_string_functions']. (UNKNOWN_SETTING) (version 23.3.2.1)

This trival PR fixes the typo so the setting matches the documentation.
